### PR TITLE
Fixed links pointing to beta.docs.qmk.fm

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ See [the build guide](guide.md) for more information.
 
 Firmware is available in the QMK repository under the name `peej/lumberjack`.
 
-Follow the [QMK firmware instructions](https://beta.docs.qmk.fm/using-qmk/guides/flashing/flashing) to build and flash the firmware.
+Follow the [QMK firmware instructions](https://docs.qmk.fm/#/flashing) to build and flash the firmware.
 
 To put the board into bootloader mode so it is ready to recieve firmware, press and hold the BOOT button (SW2) while pressing and releasing the RESET button (SW1). The board will now be detected as an USBasp device and can have the firmware flashed via the USB port.
 

--- a/guide.md
+++ b/guide.md
@@ -202,7 +202,7 @@ A bootloader is a piece of software on the microprocessor which can be used to f
 You will need to flash the microprocessor with a bootloader. To do this you will need another device which can be connected to the ISP headers and used to flash the bootloader to the chip. Since Lumberjack is the same as the Plaid, we can use the same bootloader.
 
 * Download the [Plaid bootloader](https://github.com/hsgw/USBaspLoader/tree/plaid) and follow the instructions to compile the bootloader.
-* Follow the [QMK ISP flashing guide](https://beta.docs.qmk.fm/using-qmk/guides/keyboard-building/isp_flashing_guide) to get the bootloader onto the chip.
+* Follow the [QMK ISP flashing guide](https://docs.qmk.fm/#/isp_flashing_guide) to get the bootloader onto the chip.
 
 Don't forget to set the fuses: low `0xd7`, high `0xd0`, extended `0xfc`.
 
@@ -210,7 +210,7 @@ There is a pre-compiled bootloader + firmware in the [bootloader directory](boot
 
 ### Firmware
 
-Follow the [QMK firmware instructions](https://beta.docs.qmk.fm/using-qmk/guides/flashing/flashing) to build and flash the firmware.
+Follow the [QMK firmware instructions](https://docs.qmk.fm/#/flashing) to build and flash the firmware.
 
 `qmk flash -kb peej/lumberjack`
 


### PR DESCRIPTION
Fixed a `beta.docs.qmk.fm` link since those are not working anymore.

Replaced: 
https://beta.docs.qmk.fm/using-qmk/guides/flashing/flashing
with
https://docs.qmk.fm/#/flashing